### PR TITLE
Rocko

### DIFF
--- a/meta-openpli/recipes-extended/libarchive/libarchive/libarchive-CVE-2013-0211.patch
+++ b/meta-openpli/recipes-extended/libarchive/libarchive/libarchive-CVE-2013-0211.patch
@@ -1,0 +1,37 @@
+From 2f55d6bd308ea61975558c2469ae349dba297e89 Mon Sep 17 00:00:00 2001
+From: Robert Yang <liezhi.yang@windriver.com>
+Date: Sat, 22 Feb 2014 14:35:59 +0800
+Subject: [PATCH] Fix CVE-2013-0211
+
+This patch comes from:https://github.com/libarchive/libarchive/commit/22531545514043e04633e1c015c7540b9de9dbe4
+
+Upstream-Status: Backport
+
+Signed-off-by: Baogen shang <baogen.shang@windriver.com>
+
+Update the patch because of uprev on 20140222
+
+Signed-off-by: Robert Yang <liezhi.yang@windriver.com>
+---
+ libarchive/archive_write.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/libarchive/archive_write.c b/libarchive/archive_write.c
+index a3d1a33..a323588 100644
+--- a/libarchive/archive_write.c
++++ b/libarchive/archive_write.c
+@@ -671,8 +671,12 @@ static ssize_t
+ _archive_write_data(struct archive *_a, const void *buff, size_t s)
+ {
+ 	struct archive_write *a = (struct archive_write *)_a;
++	const size_t max_write = INT_MAX;
+ 	archive_check_magic(&a->archive, ARCHIVE_WRITE_MAGIC,
+ 	    ARCHIVE_STATE_DATA, "archive_write_data");
++	/* In particular, this catches attempts to pass negative values. */
++	if (s > max_write)
++		s = max_write;
+ 	archive_clear_error(&a->archive);
+ 	return ((a->format_write_data)(a, buff, s));
+ }
+-- 
+1.8.2.1

--- a/meta-openpli/recipes-extended/libarchive/libarchive/pkgconfig.patch
+++ b/meta-openpli/recipes-extended/libarchive/libarchive/pkgconfig.patch
@@ -1,0 +1,25 @@
+Use pkg-config for the libxml2 dependency, not the -config script.
+
+Upstream-Status: Pending
+
+RP 2014/5/22
+
+Index: libarchive-3.1.2/configure.ac
+===================================================================
+--- libarchive-3.1.2.orig/configure.ac	2013-02-09 17:23:03.000000000 +0000
++++ libarchive-3.1.2/configure.ac	2014-05-13 15:26:45.446499108 +0000
+@@ -329,10 +329,10 @@
+   AS_HELP_STRING([--without-expat], [Don't build support for xar through expat]))
+ 
+ if test "x$with_xml2" != "xno"; then
+-  AC_PATH_PROG([XML2_CONFIG], [xml2-config],, [${PATH}])
+-  if test "x$XML2_CONFIG" != "x"; then
+-    CPPFLAGS="${CPPFLAGS} `${XML2_CONFIG} --cflags`"
+-    LIBS="${LIBS} `${XML2_CONFIG} --libs`"
++  PKG_CHECK_MODULES(PKG_XML2, [libxml-2.0],,)
++  if test "x$PKG_XML2_CFLAGS" != "x"; then
++    CPPFLAGS="${CPPFLAGS} ${PKG_XML2_CFLAGS}"
++    LIBS="${LIBS} ${PKG_XML2_LIBS}"
+     AC_CHECK_LIB(xml2,xmlInitParser,[true],AC_MSG_FAILURE(Missing xml2 library))
+   else
+     AC_CHECK_LIB(xml2,xmlInitParser)

--- a/meta-openpli/recipes-extended/libarchive/libarchive_3.1.2.bb
+++ b/meta-openpli/recipes-extended/libarchive/libarchive_3.1.2.bb
@@ -1,0 +1,51 @@
+SUMMARY = "Support for reading various archive formats"
+DESCRIPTION = "C library and command-line tools for reading and writing tar, cpio, zip, ISO, and other archive formats"
+HOMEPAGE = "http://www.libarchive.org/"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b4e3ffd607d6686c6cb2f63394370841"
+
+DEPENDS = "e2fsprogs-native"
+
+PACKAGECONFIG ?= "libxml2 zlib bz2"
+
+PACKAGECONFIG_append_class-target = "\
+	${@bb.utils.contains('DISTRO_FEATURES', 'acl', 'acl', '', d)} \
+	${@bb.utils.contains('DISTRO_FEATURES', 'xattr', 'xattr', '', d)} \
+	${@bb.utils.contains('DISTRO_FEATURES', 'largefile', 'largefile', '', d)} \
+"
+
+PACKAGECONFIG_append_class-nativesdk = " largefile"
+
+PACKAGECONFIG[acl] = "--enable-acl,--disable-acl,acl,"
+PACKAGECONFIG[xattr] = "--enable-xattr,--disable-xattr,attr,"
+PACKAGECONFIG[largefile] = "--enable-largefile,--disable-largefile,,"
+PACKAGECONFIG[zlib] = "--with-zlib,--without-zlib,zlib,"
+PACKAGECONFIG[bz2] = "--with-bz2lib,--without-bz2lib,bzip2,"
+PACKAGECONFIG[xz] = "--with-lzmadec --with-lzma,--without-lzmadec --without-lzma,xz,"
+PACKAGECONFIG[openssl] = "--with-openssl,--without-openssl,openssl,"
+PACKAGECONFIG[libxml2] = "--with-xml2,--without-xml2,libxml2,"
+PACKAGECONFIG[expat] = "--with-expat,--without-expat,expat,"
+PACKAGECONFIG[lzo] = "--with-lzo2,--without-lzo2,lzo,"
+PACKAGECONFIG[nettle] = "--with-nettle,--without-nettle,nettle,"
+
+SRC_URI = "http://libarchive.org/downloads/libarchive-${PV}.tar.gz \
+           file://libarchive-CVE-2013-0211.patch \
+           file://pkgconfig.patch \
+           "
+
+SRC_URI[md5sum] = "efad5a503f66329bb9d2f4308b5de98a"
+SRC_URI[sha256sum] = "eb87eacd8fe49e8d90c8fdc189813023ccc319c5e752b01fb6ad0cc7b2c53d5e"
+
+inherit autotools-brokensep lib_package pkgconfig
+
+CPPFLAGS += "-I${WORKDIR}/extra-includes"
+
+do_configure[cleandirs] += "${WORKDIR}/extra-includes"
+do_configure_prepend() {
+	# We just need the headers for some type constants, so no need to
+	# build all of e2fsprogs for the target
+	cp -R ${STAGING_INCDIR_NATIVE}/ext2fs ${WORKDIR}/extra-includes/
+}
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Fix telnet Warning on DM800HD

Fix Warning when extracting archive entry on DM800HD ..
`Warning when extracting archive entry '/usr/': Can't restore time`
