### PR TITLE
Fix tmp mount

### DIFF
--- a/meta-openpli/recipes-core/base-files/base-files/fstab
+++ b/meta-openpli/recipes-core/base-files/base-files/fstab
@@ -3,3 +3,4 @@ proc                 /proc                proc       defaults              0  0
 devpts               /dev/pts             devpts     mode=0620,gid=5       0  0
 usbdevfs             /proc/bus/usb        usbdevfs   noauto                0  0
 tmpfs                /var/volatile        tmpfs      defaults              0  0
+tmpfs                /tmp                 tmpfs      defaults              0  0 


### PR DESCRIPTION
Before this commit the contents of a tmp were not deleted after the reboot box ..
And also some packages with contents scripts can not install it ..
`Collected errors:
 * check_data_file_clashes: Package wants to install directory /tmp/
        But that path is currently a file`