### PR TITLE
No need any more after downgrade libarchive  to 3.1.2 https://githubcom/DMM-PLi/meta-dream/commit/8c007b876ae9414cca9e0020f5e519c6f34a7cb0#diff-5d2ac0951015b5db73f2278a219a9dd7

### DIFF
--- a/meta-openpli/recipes-core/base-files/base-files/fstab
+++ b/meta-openpli/recipes-core/base-files/base-files/fstab
@@ -2,4 +2,4 @@ rootfs               /                    auto       defaults              1  1
 proc                 /proc                proc       defaults              0  0
 devpts               /dev/pts             devpts     mode=0620,gid=5       0  0
 usbdevfs             /proc/bus/usb        usbdevfs   noauto                0  0
-tmpfs                /tmp                 tmpfs      defaults              0  0 
+tmpfs                /var/volatile        tmpfs      defaults              0  0

--- a/meta-openpli/recipes-core/base-files/base-files/fstab
+++ b/meta-openpli/recipes-core/base-files/base-files/fstab
@@ -2,5 +2,4 @@ rootfs               /                    auto       defaults              1  1
 proc                 /proc                proc       defaults              0  0
 devpts               /dev/pts             devpts     mode=0620,gid=5       0  0
 usbdevfs             /proc/bus/usb        usbdevfs   noauto                0  0
-tmpfs                /var/volatile        tmpfs      defaults              0  0
 tmpfs                /tmp                 tmpfs      defaults              0  0 


### PR DESCRIPTION
Downgrade libarchive  to 3.1.2 fix telnet warning and /tmp folder mount