### PR TITLE
Still we need it ..

### DIFF
--- a/meta-openpli/recipes-core/base-files/base-files/fstab
+++ b/meta-openpli/recipes-core/base-files/base-files/fstab
@@ -3,3 +3,4 @@ proc                 /proc                proc       defaults              0  0
 devpts               /dev/pts             devpts     mode=0620,gid=5       0  0
 usbdevfs             /proc/bus/usb        usbdevfs   noauto                0  0
 tmpfs                /var/volatile        tmpfs      defaults              0  0
+tmpfs                /tmp                 tmpfs      defaults              0  0 


### PR DESCRIPTION
/tmp does not work probably .. Still we need to mount it as tmpfs ..